### PR TITLE
Widen demo cards to 625px

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,8 +96,7 @@
     }
 
     .demo {
-      max-width: 520px;
-      margin: 0 auto 30px;
+      max-width: 625px;
       margin: 15px auto 30px;
       background: #fff;
       padding: 15px;


### PR DESCRIPTION
This increases the cards' ma-width, which means they still shrink as before on narrow devices. The great advantage of 625px is that it's spotify's threshold for 'desktop mode' in their embed. It also makes previews images of demos overall slightly larger (and therefore nicer?)