### PR TITLE
Remove duplicate soundcloud embed

### DIFF
--- a/_includes/embed.html
+++ b/_includes/embed.html
@@ -1,15 +1,4 @@
-{% if post.embed.type == "soundcloud" %}
-<iframe
-  width="100%"
-  height="292"
-  scrolling="no"
-  frameborder="no"
-  allow="autoplay"
-  src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{
-    post.embed.id
-  }}&color=%231d3459&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false&visual=true"
-></iframe>
-{% endif %} {% if post.embed.type == "youtube" %}
+{% if post.embed.type == "youtube" %}
 <iframe
   src="https://www.youtube.com/embed/{{
     post.embed.id


### PR DESCRIPTION
In 41d0a1190853d6ae12791c52e692b3afc059664f, a second soundcloud embed was added. Because all iframes are absolutely positioned (to make the aspect ratio properly locked, and get a background color behind them), we probably never saw that the duplicate was introduced.

This removes the one of the two duplicates that has been invisible for two years, that's probably the safest option by now.